### PR TITLE
Calculated properties

### DIFF
--- a/kettocritic/models.py
+++ b/kettocritic/models.py
@@ -43,7 +43,7 @@ class Reviewer(BaseModel):
 
 
 class Score(BaseModel):
-    SCORE_TYPE_LETTER = 10  # 1 - 5
+    SCORE_TYPE_LETTER = 10  # 0 - 5
     SCORE_TYPE_PERCENTAGE = 20  # 0 - 100
     SCORE_TYPE_STARS = 30  # 0 - 5
     SCORE_TYPE_CHOICES = (

--- a/kettocritic/models.py
+++ b/kettocritic/models.py
@@ -32,6 +32,10 @@ class Team(BaseModel):
     name = CharField(unique=True)
     website = CharField(unique=True)
 
+    @property
+    def num_reviewers(self):
+        return self.reviewers.count()
+
 
 class Reviewer(BaseModel):
     name = CharField(unique=True)

--- a/kettocritic/serializers.py
+++ b/kettocritic/serializers.py
@@ -42,4 +42,4 @@ class ReviewerSerializer(ModelSerializer):
 
 
 class ReviewSerializer(ModelSerializer):
-    fields = ['id', 'game', 'reviewer', 'score', 'title']
+    fields = ['id', 'description', 'created_on', 'game', 'reviewer', 'score', 'title']

--- a/kettocritic/serializers.py
+++ b/kettocritic/serializers.py
@@ -27,16 +27,19 @@ class ModelSerializer():
 
 
 class GameSerializer(ModelSerializer):
-    fields = ['name']
+    fields = ['id', 'name']
 
 
 class TeamSerializer(ModelSerializer):
-    fields = ['name', 'website']
+    fields = ['id', 'name', 'website', 'num_reviews', 'num_reviewers']
+
+    def get_num_reviews(self, instance):
+        return sum(reviewer.reviews.count() for reviewer in instance.reviewers)
 
 
 class ReviewerSerializer(ModelSerializer):
-    fields = ['name', 'team']
+    fields = ['id', 'name', 'team']
 
 
 class ReviewSerializer(ModelSerializer):
-    fields = ['game', 'reviewer', 'score', 'title']
+    fields = ['id', 'game', 'reviewer', 'score', 'title']

--- a/kettocritic/serializers.py
+++ b/kettocritic/serializers.py
@@ -31,7 +31,7 @@ class GameSerializer(ModelSerializer):
 
 
 class TeamSerializer(ModelSerializer):
-    fields = ['id', 'name', 'website', 'num_reviews', 'num_reviewers']
+    fields = ['id', 'num_reviews', 'num_reviewers']
 
     def get_num_reviews(self, instance):
         return sum(reviewer.reviews.count() for reviewer in instance.reviewers)

--- a/test.py
+++ b/test.py
@@ -20,30 +20,45 @@ class FailingTests(unittest.TestCase):
         """
         drop_tables()
 
-    def test_review_view_get(self):
+    def test_team_view_get(self):
         """
-        `router.get_reviews()` is returning a list of reviews with missing 'created_on' and 'description' fields.
-        Update the endpoint so that it correctly includes the 'created_on' and 'description' fields.
+        `router.get_teams(sorts=['id'])` is returning a list of reviews with missing 'name' and 'website' fields.
+        Update the endpoint so that it correctly includes the 'name' and 'website' fields.
+        """
+        self.assertEqual(router.get_teams(sorts=['id']), [
+            {'num_reviews': 6, 'id': 1, 'name': 'IGN', 'num_reviewers': 3, 'website': 'https://www.ign.com/'},
+            {'num_reviews': 6, 'id': 2, 'name': 'metacritic', 'num_reviewers': 4, 'website': 'http://www.metacritic.com'},
+            {'num_reviews': 6, 'id': 3, 'name': 'PCGamer', 'num_reviewers': 3, 'website': 'http://www.pcgamer.com'}
+        ])
+
+    def test_review_view_get_with_normalized_score(self):
+        """
+        `router.get_reviews(sorts=['id'])` currently returns the raw score
+        `SCORE_TYPE_LETTER` 0-5
+        `SCORE_TYPE_PERCENTAGE` 0-100
+        `SCORE_TYPE_STARS` 0-5
+        We also want the ability to compare scores across different `score_type`s by normalizing the `score`s to something more
+        easily comparable. (0-100)
         """
         self.assertEqual(router.get_reviews(sorts=['id']), [
-            {'description': 'John Wall Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 1, 'title': "John Wall's Review of Assassins Creed Origins", 'score': 1, 'game': 1, 'id': 1},
-            {'description': 'Stephen Curry Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 4, 'title': "Stephen Curry's Review of Assassins Creed Origins", 'score': 2, 'game': 1, 'id': 2},
-            {'description': 'LeBron James Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 8, 'title': "LeBron James's Review of Assassins Creed Origins", 'score': 3, 'game': 1, 'id': 3},
-            {'description': 'Bradley Beal Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 2, 'title': "Bradley Beal's Review of Cities Skylines", 'score': 4, 'game': 2, 'id': 4},
-            {'description': 'Kevin Durant Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 5, 'title': "Kevin Durant's Review of Cities Skylines", 'score': 5, 'game': 2, 'id': 5},
-            {'description': 'Derrick Rose Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 9, 'title': "Derrick Rose's Review of Cities Skylines", 'score': 6, 'game': 2, 'id': 6},
-            {'description': 'Mike Scott Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 3, 'title': "Mike Scott's Review of Cuphead", 'score': 7, 'game': 3, 'id': 7},
-            {'description': 'Klay Thompson Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 6, 'title': "Klay Thompson's Review of Cuphead", 'score': 8, 'game': 3, 'id': 8},
-            {'description': 'Dwyane Wade Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 10, 'title': "Dwyane Wade's Review of Cuphead", 'score': 9, 'game': 3, 'id': 9},
-            {'description': 'John Wall Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 1, 'title': "John Wall's Review of Destiny 2", 'score': 10, 'game': 4, 'id': 10},
-            {'description': 'Draymond Green Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 7, 'title': "Draymond Green's Review of Destiny 2", 'score': 11, 'game': 4, 'id': 11},
-            {'description': 'LeBron James Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 8, 'title': "LeBron James's Review of Destiny 2", 'score': 12, 'game': 4, 'id': 12},
-            {'description': 'Bradley Beal Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 2, 'title': "Bradley Beal's Review of Super Smash Bros. for Wii U", 'score': 13, 'game': 5, 'id': 13},
-            {'description': 'Stephen Curry Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 4, 'title': "Stephen Curry's Review of Super Smash Bros. for Wii U", 'score': 14, 'game': 5, 'id': 14},
-            {'description': 'Derrick Rose Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 9, 'title': "Derrick Rose's Review of Super Smash Bros. for Wii U", 'score': 15, 'game': 5, 'id': 15},
-            {'description': 'Mike Scott Takes an in-depth look at Super Meat Boy', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 3, 'title': "Mike Scott's Review of Super Meat Boy", 'score': 16, 'game': 6, 'id': 16},
-            {'description': 'Kevin Durant Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 5, 'title': "Kevin Durant's Review of Super Smash Bros. for Wii U", 'score': 17, 'game': 5, 'id': 17},
-            {'description': 'Dwyane Wade Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 10, 'title': "Dwyane Wade's Review of Super Smash Bros. for Wii U", 'score': 18, 'game': 5, 'id': 18}
+            {'game': 1, 'score': 1, 'id': 1, 'description': 'John Wall Takes an in-depth look at Assassins Creed Origins', 'normalized_score': 100, 'reviewer': 1, 'created_on': '2017-10-29 21:15:16.529267', 'title': "John Wall's Review of Assassins Creed Origins"},
+            {'game': 1, 'score': 2, 'id': 2, 'description': 'Stephen Curry Takes an in-depth look at Assassins Creed Origins', 'normalized_score': 91, 'reviewer': 4, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Stephen Curry's Review of Assassins Creed Origins"},
+            {'game': 1, 'score': 3, 'id': 3, 'description': 'LeBron James Takes an in-depth look at Assassins Creed Origins', 'normalized_score': 80, 'reviewer': 8, 'created_on': '2017-10-29 21:15:16.529267', 'title': "LeBron James's Review of Assassins Creed Origins"},
+            {'game': 2, 'score': 4, 'id': 4, 'description': 'Bradley Beal Takes an in-depth look at Cities Skylines', 'normalized_score': 60, 'reviewer': 2, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Bradley Beal's Review of Cities Skylines"},
+            {'game': 2, 'score': 5, 'id': 5, 'description': 'Kevin Durant Takes an in-depth look at Cities Skylines', 'normalized_score': 68, 'reviewer': 5, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Kevin Durant's Review of Cities Skylines"},
+            {'game': 2, 'score': 6, 'id': 6, 'description': 'Derrick Rose Takes an in-depth look at Cities Skylines', 'normalized_score': 80, 'reviewer': 9, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Derrick Rose's Review of Cities Skylines"},
+            {'game': 3, 'score': 7, 'id': 7, 'description': 'Mike Scott Takes an in-depth look at Cuphead', 'normalized_score': 80, 'reviewer': 3, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Mike Scott's Review of Cuphead"},
+            {'game': 3, 'score': 8, 'id': 8, 'description': 'Klay Thompson Takes an in-depth look at Cuphead', 'normalized_score': 85, 'reviewer': 6, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Klay Thompson's Review of Cuphead"},
+            {'game': 3, 'score': 9, 'id': 9, 'description': 'Dwyane Wade Takes an in-depth look at Cuphead', 'normalized_score': 60, 'reviewer': 10, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Dwyane Wade's Review of Cuphead"},
+            {'game': 4, 'score': 10, 'id': 10, 'description': 'John Wall Takes an in-depth look at Destiny 2', 'normalized_score': 60, 'reviewer': 1, 'created_on': '2017-10-29 21:15:16.529267', 'title': "John Wall's Review of Destiny 2"},
+            {'game': 4, 'score': 11, 'id': 11, 'description': 'Draymond Green Takes an in-depth look at Destiny 2', 'normalized_score': 61, 'reviewer': 7, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Draymond Green's Review of Destiny 2"},
+            {'game': 4, 'score': 12, 'id': 12, 'description': 'LeBron James Takes an in-depth look at Destiny 2', 'normalized_score': 40, 'reviewer': 8, 'created_on': '2017-10-29 21:15:16.529267', 'title': "LeBron James's Review of Destiny 2"},
+            {'game': 5, 'score': 13, 'id': 13, 'description': 'Bradley Beal Takes an in-depth look at Super Smash Bros. for Wii U', 'normalized_score': 100, 'reviewer': 2, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Bradley Beal's Review of Super Smash Bros. for Wii U"},
+            {'game': 5, 'score': 14, 'id': 14, 'description': 'Stephen Curry Takes an in-depth look at Super Smash Bros. for Wii U', 'normalized_score': 97, 'reviewer': 4, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Stephen Curry's Review of Super Smash Bros. for Wii U"},
+            {'game': 5, 'score': 15, 'id': 15, 'description': 'Derrick Rose Takes an in-depth look at Super Smash Bros. for Wii U', 'normalized_score': 100, 'reviewer': 9, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Derrick Rose's Review of Super Smash Bros. for Wii U"},
+            {'game': 6, 'score': 16, 'id': 16, 'description': 'Mike Scott Takes an in-depth look at Super Meat Boy', 'normalized_score': 80, 'reviewer': 3, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Mike Scott's Review of Super Meat Boy"},
+            {'game': 5, 'score': 17, 'id': 17, 'description': 'Kevin Durant Takes an in-depth look at Super Smash Bros. for Wii U', 'normalized_score': 88, 'reviewer': 5, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Kevin Durant's Review of Super Smash Bros. for Wii U"},
+            {'game': 5, 'score': 18, 'id': 18, 'description': 'Dwyane Wade Takes an in-depth look at Super Smash Bros. for Wii U', 'normalized_score': 80, 'reviewer': 10, 'created_on': '2017-10-29 21:15:16.529267', 'title': "Dwyane Wade's Review of Super Smash Bros. for Wii U"}
         ])
 
     def test_game_view_get_with_calculated_values(self):
@@ -52,6 +67,12 @@ class FailingTests(unittest.TestCase):
         present the average score for each game.
         """
         self.assertEqual(router.get_games(sorts=['id']), [
+            {'name': 'Assassins Creed Origins', 'id': 1, 'average_score': 90.33333333333333},
+            {'name': 'Cities Skylines', 'id': 2, 'average_score': 69.33333333333333},
+            {'name': 'Cuphead', 'id': 3, 'average_score': 75.0},
+            {'name': 'Destiny 2', 'id': 4, 'average_score': 53.666666666666664},
+            {'name': 'Super Smash Bros. for Wii U', 'id': 5, 'average_score': 93.0},
+            {'name': 'Super Meat Boy', 'id': 6, 'average_score': 80.0}
         ])
 
     def test_game_view_get_with_filter(self):
@@ -63,10 +84,10 @@ class FailingTests(unittest.TestCase):
         Hard Mode: Implement filtering at the ORM level
         """
         self.assertEqual(router.get_games(filters={'average_score__gte': 70}), [
-            {'name': 'Assassins Creed Origins', 'id': 1},
-            {'name': 'Cuphead', 'id': 3},
-            {'name': 'Super Smash Bros. for Wii U', 'id': 5},
-            {'name': 'Super Meat Boy', 'id': 6},
+            {'average_score': 90.33333333333333, 'name': 'Assassins Creed Origins', 'id': 1},
+            {'average_score': 75.0, 'name': 'Cuphead', 'id': 3},
+            {'average_score': 93.0, 'name': 'Super Smash Bros. for Wii U', 'id': 5},
+            {'average_score': 80.0, 'name': 'Super Meat Boy', 'id': 6}
         ])
 
     def test_review_view_get_with_sort(self):
@@ -77,24 +98,24 @@ class FailingTests(unittest.TestCase):
         Note: Test should not fail if you complete the extra credit
         """
         self.assertEqual(router.get_reviews(sorts=['reviewer__team__name', 'id']), [
-            {'description': 'John Wall Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 1, 'title': "John Wall's Review of Assassins Creed Origins", 'score': 1, 'game': 1},
-            {'description': 'Bradley Beal Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 2, 'title': "Bradley Beal's Review of Cities Skylines", 'score': 4, 'game': 2},
-            {'description': 'Mike Scott Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 3, 'title': "Mike Scott's Review of Cuphead", 'score': 7, 'game': 3},
-            {'description': 'John Wall Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 1, 'title': "John Wall's Review of Destiny 2", 'score': 10, 'game': 4},
-            {'description': 'Bradley Beal Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 2, 'title': "Bradley Beal's Review of Super Smash Bros. for Wii U", 'score': 13, 'game': 5},
-            {'description': 'Mike Scott Takes an in-depth look at Super Meat Boy', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 3, 'title': "Mike Scott's Review of Super Meat Boy", 'score': 16, 'game': 6},
-            {'description': 'Stephen Curry Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 4, 'title': "Stephen Curry's Review of Assassins Creed Origins", 'score': 2, 'game': 1},
-            {'description': 'Kevin Durant Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 5, 'title': "Kevin Durant's Review of Cities Skylines", 'score': 5, 'game': 2},
-            {'description': 'Klay Thompson Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 6, 'title': "Klay Thompson's Review of Cuphead", 'score': 8, 'game': 3},
-            {'description': 'Draymond Green Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 7, 'title': "Draymond Green's Review of Destiny 2", 'score': 11, 'game': 4},
-            {'description': 'Stephen Curry Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 4, 'title': "Stephen Curry's Review of Super Smash Bros. for Wii U", 'score': 14, 'game': 5},
-            {'description': 'Kevin Durant Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 5, 'title': "Kevin Durant's Review of Super Smash Bros. for Wii U", 'score': 17, 'game': 5},
-            {'description': 'LeBron James Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 8, 'title': "LeBron James's Review of Assassins Creed Origins", 'score': 3, 'game': 1},
-            {'description': 'Derrick Rose Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 9, 'title': "Derrick Rose's Review of Cities Skylines", 'score': 6, 'game': 2},
-            {'description': 'Dwyane Wade Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 10, 'title': "Dwyane Wade's Review of Cuphead", 'score': 9, 'game': 3},
-            {'description': 'LeBron James Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 8, 'title': "LeBron James's Review of Destiny 2", 'score': 12, 'game': 4},
-            {'description': 'Derrick Rose Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 9, 'title': "Derrick Rose's Review of Super Smash Bros. for Wii U", 'score': 15, 'game': 5},
-            {'description': 'Dwyane Wade Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 10, 'title': "Dwyane Wade's Review of Super Smash Bros. for Wii U", 'score': 18, 'game': 5}
+            {'description': 'John Wall Takes an in-depth look at Assassins Creed Origins', 'reviewer': 1, 'created_on': '2017-10-29 21:15:16.529267', 'id': 1, 'normalized_score': 100, 'score': 1, 'game': 1, 'title': "John Wall's Review of Assassins Creed Origins"},
+            {'description': 'Bradley Beal Takes an in-depth look at Cities Skylines', 'reviewer': 2, 'created_on': '2017-10-29 21:15:16.529267', 'id': 4, 'normalized_score': 60, 'score': 4, 'game': 2, 'title': "Bradley Beal's Review of Cities Skylines"},
+            {'description': 'Mike Scott Takes an in-depth look at Cuphead', 'reviewer': 3, 'created_on': '2017-10-29 21:15:16.529267', 'id': 7, 'normalized_score': 80, 'score': 7, 'game': 3, 'title': "Mike Scott's Review of Cuphead"},
+            {'description': 'John Wall Takes an in-depth look at Destiny 2', 'reviewer': 1, 'created_on': '2017-10-29 21:15:16.529267', 'id': 10, 'normalized_score': 60, 'score': 10, 'game': 4, 'title': "John Wall's Review of Destiny 2"},
+            {'description': 'Bradley Beal Takes an in-depth look at Super Smash Bros. for Wii U', 'reviewer': 2, 'created_on': '2017-10-29 21:15:16.529267', 'id': 13, 'normalized_score': 100, 'score': 13, 'game': 5, 'title': "Bradley Beal's Review of Super Smash Bros. for Wii U"},
+            {'description': 'Mike Scott Takes an in-depth look at Super Meat Boy', 'reviewer': 3, 'created_on': '2017-10-29 21:15:16.529267', 'id': 16, 'normalized_score': 80, 'score': 16, 'game': 6, 'title': "Mike Scott's Review of Super Meat Boy"},
+            {'description': 'Stephen Curry Takes an in-depth look at Assassins Creed Origins', 'reviewer': 4, 'created_on': '2017-10-29 21:15:16.529267', 'id': 2, 'normalized_score': 91, 'score': 2, 'game': 1, 'title': "Stephen Curry's Review of Assassins Creed Origins"},
+            {'description': 'Kevin Durant Takes an in-depth look at Cities Skylines', 'reviewer': 5, 'created_on': '2017-10-29 21:15:16.529267', 'id': 5, 'normalized_score': 68, 'score': 5, 'game': 2, 'title': "Kevin Durant's Review of Cities Skylines"},
+            {'description': 'Klay Thompson Takes an in-depth look at Cuphead', 'reviewer': 6, 'created_on': '2017-10-29 21:15:16.529267', 'id': 8, 'normalized_score': 85, 'score': 8, 'game': 3, 'title': "Klay Thompson's Review of Cuphead"},
+            {'description': 'Draymond Green Takes an in-depth look at Destiny 2', 'reviewer': 7, 'created_on': '2017-10-29 21:15:16.529267', 'id': 11, 'normalized_score': 61, 'score': 11, 'game': 4, 'title': "Draymond Green's Review of Destiny 2"},
+            {'description': 'Stephen Curry Takes an in-depth look at Super Smash Bros. for Wii U', 'reviewer': 4, 'created_on': '2017-10-29 21:15:16.529267', 'id': 14, 'normalized_score': 97, 'score': 14, 'game': 5, 'title': "Stephen Curry's Review of Super Smash Bros. for Wii U"},
+            {'description': 'Kevin Durant Takes an in-depth look at Super Smash Bros. for Wii U', 'reviewer': 5, 'created_on': '2017-10-29 21:15:16.529267', 'id': 17, 'normalized_score': 88, 'score': 17, 'game': 5, 'title': "Kevin Durant's Review of Super Smash Bros. for Wii U"},
+            {'description': 'LeBron James Takes an in-depth look at Assassins Creed Origins', 'reviewer': 8, 'created_on': '2017-10-29 21:15:16.529267', 'id': 3, 'normalized_score': 80, 'score': 3, 'game': 1, 'title': "LeBron James's Review of Assassins Creed Origins"},
+            {'description': 'Derrick Rose Takes an in-depth look at Cities Skylines', 'reviewer': 9, 'created_on': '2017-10-29 21:15:16.529267', 'id': 6, 'normalized_score': 80, 'score': 6, 'game': 2, 'title': "Derrick Rose's Review of Cities Skylines"},
+            {'description': 'Dwyane Wade Takes an in-depth look at Cuphead', 'reviewer': 10, 'created_on': '2017-10-29 21:15:16.529267', 'id': 9, 'normalized_score': 60, 'score': 9, 'game': 3, 'title': "Dwyane Wade's Review of Cuphead"},
+            {'description': 'LeBron James Takes an in-depth look at Destiny 2', 'reviewer': 8, 'created_on': '2017-10-29 21:15:16.529267', 'id': 12, 'normalized_score': 40, 'score': 12, 'game': 4, 'title': "LeBron James's Review of Destiny 2"},
+            {'description': 'Derrick Rose Takes an in-depth look at Super Smash Bros. for Wii U', 'reviewer': 9, 'created_on': '2017-10-29 21:15:16.529267', 'id': 15, 'normalized_score': 100, 'score': 15, 'game': 5, 'title': "Derrick Rose's Review of Super Smash Bros. for Wii U"},
+            {'description': 'Dwyane Wade Takes an in-depth look at Super Smash Bros. for Wii U', 'reviewer': 10, 'created_on': '2017-10-29 21:15:16.529267', 'id': 18, 'normalized_score': 80, 'score': 18, 'game': 5, 'title': "Dwyane Wade's Review of Super Smash Bros. for Wii U"}
         ])
 
 

--- a/test.py
+++ b/test.py
@@ -26,24 +26,32 @@ class FailingTests(unittest.TestCase):
         Update the endpoint so that it correctly includes the 'created_on' and 'description' fields.
         """
         self.assertEqual(router.get_reviews(sorts=['id']), [
-            {'description': 'John Wall Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 1, 'title': "John Wall's Review of Assassins Creed Origins", 'score': 1, 'game': 1},
-            {'description': 'Stephen Curry Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 4, 'title': "Stephen Curry's Review of Assassins Creed Origins", 'score': 2, 'game': 1},
-            {'description': 'LeBron James Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 8, 'title': "LeBron James's Review of Assassins Creed Origins", 'score': 3, 'game': 1},
-            {'description': 'Bradley Beal Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 2, 'title': "Bradley Beal's Review of Cities Skylines", 'score': 4, 'game': 2},
-            {'description': 'Kevin Durant Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 5, 'title': "Kevin Durant's Review of Cities Skylines", 'score': 5, 'game': 2},
-            {'description': 'Derrick Rose Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 9, 'title': "Derrick Rose's Review of Cities Skylines", 'score': 6, 'game': 2},
-            {'description': 'Mike Scott Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 3, 'title': "Mike Scott's Review of Cuphead", 'score': 7, 'game': 3},
-            {'description': 'Klay Thompson Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 6, 'title': "Klay Thompson's Review of Cuphead", 'score': 8, 'game': 3},
-            {'description': 'Dwyane Wade Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 10, 'title': "Dwyane Wade's Review of Cuphead", 'score': 9, 'game': 3},
-            {'description': 'John Wall Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 1, 'title': "John Wall's Review of Destiny 2", 'score': 10, 'game': 4},
-            {'description': 'Draymond Green Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 7, 'title': "Draymond Green's Review of Destiny 2", 'score': 11, 'game': 4},
-            {'description': 'LeBron James Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 8, 'title': "LeBron James's Review of Destiny 2", 'score': 12, 'game': 4},
-            {'description': 'Bradley Beal Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 2, 'title': "Bradley Beal's Review of Super Smash Bros. for Wii U", 'score': 13, 'game': 5},
-            {'description': 'Stephen Curry Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 4, 'title': "Stephen Curry's Review of Super Smash Bros. for Wii U", 'score': 14, 'game': 5},
-            {'description': 'Derrick Rose Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 9, 'title': "Derrick Rose's Review of Super Smash Bros. for Wii U", 'score': 15, 'game': 5},
-            {'description': 'Mike Scott Takes an in-depth look at Super Meat Boy', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 3, 'title': "Mike Scott's Review of Super Meat Boy", 'score': 16, 'game': 6},
-            {'description': 'Kevin Durant Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 5, 'title': "Kevin Durant's Review of Super Smash Bros. for Wii U", 'score': 17, 'game': 5},
-            {'description': 'Dwyane Wade Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 10, 'title': "Dwyane Wade's Review of Super Smash Bros. for Wii U", 'score': 18, 'game': 5}
+            {'description': 'John Wall Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 1, 'title': "John Wall's Review of Assassins Creed Origins", 'score': 1, 'game': 1, 'id': 1},
+            {'description': 'Stephen Curry Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 4, 'title': "Stephen Curry's Review of Assassins Creed Origins", 'score': 2, 'game': 1, 'id': 2},
+            {'description': 'LeBron James Takes an in-depth look at Assassins Creed Origins', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 8, 'title': "LeBron James's Review of Assassins Creed Origins", 'score': 3, 'game': 1, 'id': 3},
+            {'description': 'Bradley Beal Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 2, 'title': "Bradley Beal's Review of Cities Skylines", 'score': 4, 'game': 2, 'id': 4},
+            {'description': 'Kevin Durant Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 5, 'title': "Kevin Durant's Review of Cities Skylines", 'score': 5, 'game': 2, 'id': 5},
+            {'description': 'Derrick Rose Takes an in-depth look at Cities Skylines', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 9, 'title': "Derrick Rose's Review of Cities Skylines", 'score': 6, 'game': 2, 'id': 6},
+            {'description': 'Mike Scott Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 3, 'title': "Mike Scott's Review of Cuphead", 'score': 7, 'game': 3, 'id': 7},
+            {'description': 'Klay Thompson Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 6, 'title': "Klay Thompson's Review of Cuphead", 'score': 8, 'game': 3, 'id': 8},
+            {'description': 'Dwyane Wade Takes an in-depth look at Cuphead', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 10, 'title': "Dwyane Wade's Review of Cuphead", 'score': 9, 'game': 3, 'id': 9},
+            {'description': 'John Wall Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 1, 'title': "John Wall's Review of Destiny 2", 'score': 10, 'game': 4, 'id': 10},
+            {'description': 'Draymond Green Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 7, 'title': "Draymond Green's Review of Destiny 2", 'score': 11, 'game': 4, 'id': 11},
+            {'description': 'LeBron James Takes an in-depth look at Destiny 2', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 8, 'title': "LeBron James's Review of Destiny 2", 'score': 12, 'game': 4, 'id': 12},
+            {'description': 'Bradley Beal Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 2, 'title': "Bradley Beal's Review of Super Smash Bros. for Wii U", 'score': 13, 'game': 5, 'id': 13},
+            {'description': 'Stephen Curry Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 4, 'title': "Stephen Curry's Review of Super Smash Bros. for Wii U", 'score': 14, 'game': 5, 'id': 14},
+            {'description': 'Derrick Rose Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 9, 'title': "Derrick Rose's Review of Super Smash Bros. for Wii U", 'score': 15, 'game': 5, 'id': 15},
+            {'description': 'Mike Scott Takes an in-depth look at Super Meat Boy', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 3, 'title': "Mike Scott's Review of Super Meat Boy", 'score': 16, 'game': 6, 'id': 16},
+            {'description': 'Kevin Durant Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 5, 'title': "Kevin Durant's Review of Super Smash Bros. for Wii U", 'score': 17, 'game': 5, 'id': 17},
+            {'description': 'Dwyane Wade Takes an in-depth look at Super Smash Bros. for Wii U', 'created_on': '2017-10-29 21:15:16.529267', 'reviewer': 10, 'title': "Dwyane Wade's Review of Super Smash Bros. for Wii U", 'score': 18, 'game': 5, 'id': 18}
+        ])
+
+    def test_game_view_get_with_calculated_values(self):
+        """
+        `router.get_games(sorts=['id'])` currently does not include the average score. We would like to be able to calculate and
+        present the average score for each game.
+        """
+        self.assertEqual(router.get_games(sorts=['id']), [
         ])
 
     def test_game_view_get_with_filter(self):
@@ -55,10 +63,10 @@ class FailingTests(unittest.TestCase):
         Hard Mode: Implement filtering at the ORM level
         """
         self.assertEqual(router.get_games(filters={'average_score__gte': 70}), [
-            {'name': 'Assassins Creed Origins'},
-            {'name': 'Cuphead'},
-            {'name': 'Super Smash Bros. for Wii U'},
-            {'name': 'Super Meat Boy'},
+            {'name': 'Assassins Creed Origins', 'id': 1},
+            {'name': 'Cuphead', 'id': 3},
+            {'name': 'Super Smash Bros. for Wii U', 'id': 5},
+            {'name': 'Super Meat Boy', 'id': 6},
         ])
 
     def test_review_view_get_with_sort(self):


### PR DESCRIPTION
- changed `test_review_view_get` to `test_team_view_get` so that this test does not start to fail as we add more serialized fields in the following questions
- add `test_review_view_get_with_normalized_score`
- add `test_game_view_get_with_calculated_values`
- update `test_game_view_get_with_filter` to include the `average_score`
- update `test_review_view_get_with_sort` to include the `normalized_score`

- updated all tests to include `id` in the output